### PR TITLE
Barcelona-pavilion fix metal roughness

### DIFF
--- a/barcelona-pavilion/materials.pbrt
+++ b/barcelona-pavilion/materials.pbrt
@@ -72,6 +72,7 @@ MakeNamedMaterial "metal"
     "string type" [ "conductor" ]
     "spectrum eta" [ "metal-Al-eta" ]
     "spectrum k" [ "metal-Al-k" ]
+    "float roughness" [ 0.01 ]
 Texture "pavet-bump" "float" "imagemap"
     "string filename" [ "textures/Mies-BCN_M081bump.png" ]
 Texture "pavet-kd-img" "spectrum" "imagemap"


### PR DESCRIPTION
The default roughness value has been adjusted in pbrt-v4. It is now explicitly specified for the metal material to align with the pbrt-v3 appearance.